### PR TITLE
can use sku filenames now, and progress bar works

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A [ Scrapy ](https://scrapy.org/) spider written in python that scrapes almost t
 
 ## How to Run
 
-1. Install [ scrapy ](https://scrapy.org/) (assuming you already have python installed)
+1. Install [ scrapy ](https://scrapy.org/) and [ tqdm ](https://tqdm.github.io/) (assuming you already have python installed)
 ```cmd
-pip install scrapy
+pip install scrapy tqdm
 ```
 > Tip: if the installation fails, you might want to try installing scrapy in a [ virtualenv ](https://docs.python.org/3/tutorial/venv.html)
 
@@ -20,11 +20,13 @@ pip install scrapy
 ```
 > Feel free to change `FILES_STORE` to whatever suits your needs
 
-3. Run the `parts` spider:
+3. set `SKU_FILE_NAMES` (also defined in `settings.py`). By default, file names are the full product name as displayed on the goBILDA website. These names are long, which can cause problems with uploading to Fusion. To get filenames that consist only of the part's SKU, set `SKU_FILE_NAMES` to `True`.
+
+4. Run the `parts` spider:
 ```cmd
 scrapy crawl parts
 ```
-4. Wait for the `FILES_STORE` to populate, and you are good to go!
+5. Wait for the `FILES_STORE` to populate, and you are good to go!
 > Note: there will be some empty folders left behind in the models folder, like `full` and some with `assembly` in the name. Don't worry, nothing went wrong, I just didn't bother trying to find a simple solution to delete them.
 
 ## How it works

--- a/gobilda_parts_bot/pipelines.py
+++ b/gobilda_parts_bot/pipelines.py
@@ -10,7 +10,7 @@ import os
 import re
 from itemadapter import ItemAdapter
 import zipfile
-from gobilda_parts_bot.settings import FILES_STORE
+from gobilda_parts_bot.settings import FILES_STORE, SKU_FILE_NAMES
 
 def get_valid_filename(name):
     s = str(name).strip().replace(' ', '_')
@@ -24,8 +24,7 @@ class GobildaPartsBotPipeline:
             path = adapter['files'][0]['path']
             # Item loaders give us a list with one value, so we have to access the first
             # element of the list to get the actual string data
-            sku = adapter['sku'][0]
-            name = get_valid_filename(adapter['name'][0])
+            name = adapter['sku'][0] if SKU_FILE_NAMES else get_valid_filename(adapter['name'][0])
 
             zip_path = f'{FILES_STORE}/{path}' 
             if exists(zip_path):

--- a/gobilda_parts_bot/settings.py
+++ b/gobilda_parts_bot/settings.py
@@ -69,6 +69,11 @@ ITEM_PIPELINES = {
 
 FILES_STORE = 'models'
 
+# Change filenames to be just SKUs instead of long product names
+# can be useful because Fusion refuses to upload files if their
+# names are too long. uses sku if True, full name if False.
+SKU_FILE_NAMES = False
+
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
 #AUTOTHROTTLE_ENABLED = True

--- a/gobilda_parts_bot/spiders/parts_spider.py
+++ b/gobilda_parts_bot/spiders/parts_spider.py
@@ -1,6 +1,11 @@
+from msilib.schema import File
 import scrapy
 from scrapy.loader import ItemLoader
 from gobilda_parts_bot.items import Product
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+import sys
+
 
 class PartsSpider(scrapy.Spider):
 	name = "parts"
@@ -11,17 +16,20 @@ class PartsSpider(scrapy.Spider):
 		'https://www.gobilda.com/hardware/',
 	]
 
+	pbar = tqdm(total=850, file = sys.stdout) # Init pbar
+
 	def parse(self, response):
-        # Get the link attribute from a product box
-		partsList = response.css('li.product a')
-		if partsList:
-			# Sometimes, catalog pages are within others, so we have to recursively
-			# go through each page to get to actual parts
-			yield from response.follow_all(partsList, self.parse)
-		else:
-			# We are at an actual part page, with the step file,
-			# so we process the actual values scraped from the page
-			yield self.parse_product_page(response)
+		with logging_redirect_tqdm():
+			# Get the link attribute from a product box
+			partsList = response.css('li.product a')
+			if partsList:
+				# Sometimes, catalog pages are within others, so we have to recursively
+				# go through each page to get to actual parts
+				yield from response.follow_all(partsList, self.parse)
+			else:
+				# We are at an actual part page, with the step file,
+				# so we process the actual values scraped from the page
+				yield self.parse_product_page(response)
 
 	def parse_product_page(self, response):
 		step_file = response.css('a.ext-zip::attr(href)').get()
@@ -31,5 +39,6 @@ class PartsSpider(scrapy.Spider):
 			loader.add_css('sku', 'span.productView-sku-input::text')
 			loader.add_value('file_urls', [f'https://www.gobilda.com{step_file}'])
 			loader.add_value('name', name)
+			PartsSpider.pbar.update(n=1)
 			return loader.load_item()
 		


### PR DESCRIPTION
These tweaks add a setting to set filenames to just the part's SKU, and add a simple progress bar so you can guesstimate how long it will take.  
When I initially tried to upload to fusion, it wouldn't let me upload many (if not all) of the files, claiming that the filenames were too long. With just the SKUs, every part uploads fine (with one exception - see below). This seems to have been the reason some of your files failed to upload; I'm guessing the filename length limit applies to the complete path to the file, which left your parts just barely under the limit (except the 10 or so that weren't). While this isn't conclusive evidence, the problem seems to be fixed, on my computer at least (famous last words, I know).
The one part that didn't upload was part 44429, the Hitech servo programmer, which didn't work because the zip files in the downloads section are not step files.